### PR TITLE
Clear the process info if it shuts down gracefully

### DIFF
--- a/src/pytest_mysql/executor.py
+++ b/src/pytest_mysql/executor.py
@@ -121,6 +121,7 @@ class MySQLExecutor(TCPExecutor):
             user=self.user
         )
         subprocess.check_output(shutdown_command, shell=True)
+        self._clear_process()
 
     def stop(self):
         """Stop the server."""


### PR DESCRIPTION
Otherwise, `mirakuru.SimpleExecutor.stop` tries to `os.killpg` the server's PID, which does not exist to the moment, and fails with `OperationNotPermitted` error in the session's (technically, in the last test's) teardown.

Fixes #71
