### PR TITLE
Do not assume that mysql executables are in /usr/bin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,12 +87,12 @@ You can pick which you prefer, but remember that these settings are handled in t
 +==========================+==========================+=====================+===================+===========================+
 | Path to executable       | mysqld_exec              | --mysql-mysqld      | mysql_mysqld      | mysqld                    |
 +--------------------------+--------------------------+---------------------+-------------------+---------------------------+
-| Path to safe executable  | mysqld_safe              | --mysql-mysqld-safe | mysql_mysqld_safe | /usr/bin/mysqld_safe      |
+| Path to safe executable  | mysqld_safe              | --mysql-mysqld-safe | mysql_mysqld_safe | mysqld_safe               |
 +--------------------------+--------------------------+---------------------+-------------------+---------------------------+
-| Path to mysql_install_db | install_db               | --mysql-install-db  | mysql_install_db  | /usr/bin/mysql_install_db |
+| Path to mysql_install_db | install_db               | --mysql-install-db  | mysql_install_db  | mysql_install_db          |
 | for legacy installations |                          |                     |                   |                           |
 +--------------------------+--------------------------+---------------------+-------------------+---------------------------+
-| Path to Admin executable | admin_executable         | --mysql-admin       | mysql_admin       | /usr/bin/mysqladmin       |
+| Path to Admin executable | admin_executable         | --mysql-admin       | mysql_admin       | mysqladmin                |
 +--------------------------+--------------------------+---------------------+-------------------+---------------------------+
 | host                     | host                     | --mysql-host        | mysql_host        | localhost                 |
 +--------------------------+--------------------------+---------------------+-------------------+---------------------------+

--- a/src/pytest_mysql/plugin.py
+++ b/src/pytest_mysql/plugin.py
@@ -47,19 +47,19 @@ def pytest_addoption(parser):
     parser.addini(
         name='mysql_mysqld_safe',
         help=_help_mysqld_safe,
-        default='/usr/bin/mysqld_safe'
+        default='mysqld_safe'
     )
 
     parser.addini(
         name='mysql_admin',
         help=_help_admin,
-        default='/usr/bin/mysqladmin'
+        default='mysqladmin'
     )
 
     parser.addini(
         name='mysql_install_db',
         help=_help_install_db,
-        default='/usr/bin/mysql_install_db'
+        default='mysql_install_db'
     )
 
     parser.addini(


### PR DESCRIPTION
On macOS, it's often the case that the executables are in /opt/local/bin because they are installed by MacPorts.

Leave off the absolute path so that they get resolved through the PATH environment variable.