### PR TITLE
Use user config for shutdown method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,10 @@ jobs:
         pip install -r requirements-test.txt
     - name: Run test
       run: |
-        pytest -n 0 -k "not mysqlnoproc" --cov-report=xml
+        pytest -n 0 -k "not mysqlnoproc" --cov-report=xml --mysql-user=root
     - name: Run xdist test
       run: |
-        pytest -n 1 -k "not mysqlnoproc" --cov-report=xml:coverage-xdist.xml
+        pytest -n 1 -k "not mysqlnoproc" --cov-report=xml:coverage-xdist.xml --mysql-user=root
     - name: Run noproc test
       run: |
         pytest -n 0 -k mysqlnoproc --cov-report=xml:coverage-noproc.xml --mysql-host="127.0.0.1" --mysql-port=3333

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ CHANGELOG
 Feature
 +++++++
 
+- add `user` option to setup and tear down mysql process as non-privileged
+  user (without root permission).
 - `mysql_noproc` fixture to connect to already running mysql server
 - raise more meaningful error when the test database already exists
 

--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,10 @@ You can also create additional mysql client and process fixtures if you'd need t
 .. code-block:: python
 
     from pytest_mysql import factories
+    from getpass import getuser()
 
     mysql_my_proc = factories.mysql_proc(
-        port=None, logsdir='/tmp')
+        port=None, user=getuser())
     mysql_my = factories.mysql('mysql_my_proc')
 
 .. note::

--- a/src/pytest_mysql/executor.py
+++ b/src/pytest_mysql/executor.py
@@ -152,9 +152,18 @@ class MySQLExecutor(TCPExecutor):
     def shutdown(self):
         """Send shutdown command to the server."""
         shutdown_command = (
-            f"{self.admin_exec} --socket={self.unixsocket} --user=root shutdown"
+            f"{self.admin_exec} --socket={self.unixsocket} "
+            f"--user={self.user} shutdown"
         )
-        subprocess.check_output(shutdown_command, shell=True)
+        try:
+            subprocess.check_output(shutdown_command, shell=True)
+        except subprocess.CalledProcessError:
+            # Fallback to using root user for shutdown
+            shutdown_command = (
+                f"{self.admin_exec} --socket={self.unixsocket} "
+                f"--user=root shutdown"
+            )
+            subprocess.check_output(shutdown_command, shell=True)
 
     def stop(self, sig=None, exp_sig=None):
         """Stop the server."""

--- a/src/pytest_mysql/factories/noprocess.py
+++ b/src/pytest_mysql/factories/noprocess.py
@@ -27,12 +27,13 @@ from pytest_mysql.config import get_config
 from pytest_mysql.executor_noop import NoopMySQLExecutor
 
 
-def mysql_noproc(host=None, port=None):
+def mysql_noproc(host=None, port=None, user=None):
     """
     Process fixture factory for MySQL server.
 
     :param str host: hostname
-    :param int port:
+    :param int port: port name
+    :param str user: user name
     :rtype: func
     :returns: function which makes a redis process
 
@@ -53,9 +54,10 @@ def mysql_noproc(host=None, port=None):
         config = get_config(request)
         mysql_port = int(port or config["port"] or 3306)
         mysql_host = host or config["host"]
+        mysql_user = user or config["user"] or "root"
 
         mysql_executor = NoopMySQLExecutor(
-            user=config["user"],
+            user=mysql_user,
             host=mysql_host,
             port=mysql_port,
         )

--- a/src/pytest_mysql/factories/process.py
+++ b/src/pytest_mysql/factories/process.py
@@ -34,6 +34,7 @@ def mysql_proc(
     admin_executable=None,
     mysqld_safe=None,
     host=None,
+    user=None,
     port=-1,
     params=None,
     logs_prefix="",
@@ -46,6 +47,7 @@ def mysql_proc(
     :param str admin_executable: path to mysql_admin executable
     :param str mysqld_safe: path to mysqld_safe executable
     :param str host: hostname
+    :param str user: user name
     :param str|int|tuple|set|list port:
         exact port (e.g. '8000', 8000)
         randomly selected port (None) - any random available port
@@ -123,7 +125,7 @@ def mysql_proc(
             logfile_path=logfile_path,
             base_directory=tmpdir,
             params=mysql_params,
-            user=config["user"],
+            user=user or config["user"] or "root",
             host=mysql_host,
             port=mysql_port,
             install_db=mysql_install_db,


### PR DESCRIPTION
The shutdown method of the mysql process as well as the methods for connecting to a running mysql server should make use of the global user configuration instead of using the root user.
I ran into a similar issue that was mentioned in #242 [Access denied for user 'root'@'localhost' (using password: YES) ]. Not sure how much they are related though.

Changes proposed.