### PR TITLE
Add try/except in factories/mysql fixture

### DIFF
--- a/src/pytest_mysql/factories/client.py
+++ b/src/pytest_mysql/factories/client.py
@@ -58,7 +58,9 @@ def mysql(
     :rtype: func
     """
 
-    def _connect(connect_kwargs: dict, query_str: str, mysql_db: str) -> MySQLdb.Connection:
+    def _connect(
+            connect_kwargs: dict, query_str: str, mysql_db: str
+    ) -> MySQLdb.Connection:
         """Apply given query to a  given MySQLdb connection."""
         mysql_conn: MySQLdb.Connection = MySQLdb.connect(**connect_kwargs)
         try:
@@ -132,7 +134,9 @@ def mysql(
 
         # clean up after test that forgot to fetch selected data
         if not mysql_conn.open:
-            mysql_conn: MySQLdb.Connection = MySQLdb.connect(**connection_kwargs)
+            mysql_conn: MySQLdb.Connection = MySQLdb.connect(
+                **connection_kwargs
+            )
         try:
             mysql_conn.store_result()
         except Exception as e:
@@ -140,4 +144,5 @@ def mysql(
         query_drop_database = "DROP DATABASE IF EXISTS %s" % mysql_db
         mysql_conn.query(query_drop_database)
         mysql_conn.close()
+
     return mysql_fixture

--- a/src/pytest_mysql/factories/client.py
+++ b/src/pytest_mysql/factories/client.py
@@ -137,19 +137,21 @@ def mysql(
         except Exception as e:
             print(str(e))
         try:
+            query_drop_database = "DROP DATABASE IF EXISTS %s" % mysql_db
             if not mysql_conn.open:
                 try:
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, "DROP DATABASE IF EXISTS %s" % mysql_db
+                        connection_kwargs,
+                        query_drop_database
                     )
                 except OperationalError:
                     # Fallback to mysql connection with root user
                     connection_kwargs["user"] = "root"
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, "DROP DATABASE IF EXISTS %s" % mysql_db
-                    )
+                        connection_kwargs,
+                        query_drop_database)
             else:
-                mysql_conn.query("DROP DATABASE IF EXISTS %s" % mysql_db)
+                mysql_conn.query(query_drop_database)
             mysql_conn.close()
         except Exception as e:
             print(str(e))

--- a/src/pytest_mysql/factories/client.py
+++ b/src/pytest_mysql/factories/client.py
@@ -140,16 +140,16 @@ def mysql(
             if not mysql_conn.open:
                 try:
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, ""
+                        connection_kwargs, "DROP DATABASE IF EXISTS %s" % mysql_db
                     )
                 except OperationalError:
                     # Fallback to mysql connection with root user
                     connection_kwargs["user"] = "root"
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, ""
+                        connection_kwargs, "DROP DATABASE IF EXISTS %s" % mysql_db
                     )
-                mysql_conn.query(f"USE {mysql_db}")
-            mysql_conn.query("DROP DATABASE IF EXISTS %s" % mysql_db)
+            else:
+                mysql_conn.query("DROP DATABASE IF EXISTS %s" % mysql_db)
             mysql_conn.close()
         except Exception as e:
             print(str(e))

--- a/src/pytest_mysql/factories/client.py
+++ b/src/pytest_mysql/factories/client.py
@@ -66,7 +66,7 @@ def mysql(
         except ProgrammingError as e:
             if "database exists" in str(e):
                 raise DatabaseExists(
-                    f"Database {mysql_db} already exists. There's some test "
+                    f"Database {query_str} already exists. There's some test "
                     f"configuration error. Either you start your own server "
                     f"with the database name used in tests, or you use two "
                     f"fixtures with the same database name on the same "
@@ -140,13 +140,13 @@ def mysql(
             if not mysql_conn.open:
                 try:
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, query_str
+                        connection_kwargs, ""
                     )
                 except OperationalError:
                     # Fallback to mysql connection with root user
                     connection_kwargs["user"] = "root"
                     mysql_conn: MySQLdb.Connection = _connect(
-                        connection_kwargs, query_str
+                        connection_kwargs, ""
                     )
                 mysql_conn.query(f"USE {mysql_db}")
             mysql_conn.query("DROP DATABASE IF EXISTS %s" % mysql_db)

--- a/src/pytest_mysql/factories/client.py
+++ b/src/pytest_mysql/factories/client.py
@@ -59,7 +59,7 @@ def mysql(
     """
 
     def _connect(
-            connect_kwargs: dict, query_str: str, mysql_db: str
+        connect_kwargs: dict, query_str: str, mysql_db: str
     ) -> MySQLdb.Connection:
         """Apply given query to a  given MySQLdb connection."""
         mysql_conn: MySQLdb.Connection = MySQLdb.connect(**connect_kwargs)

--- a/tests/test_mysqlnoproc.py
+++ b/tests/test_mysqlnoproc.py
@@ -11,3 +11,17 @@ def test_mysql_noproc(mysqlnoproc_client):
     cursor.execute(QUERY)
     mysqlnoproc_client.commit()
     cursor.close()
+
+
+def test_mysql_noproc_closing_connection_not_throwing_exception(
+    mysqlnoproc_client,
+):
+    """
+    Check if closing the connection doesn't throw an exception
+    when cleaning the fixture.
+    """
+    cursor = mysqlnoproc_client.cursor()
+    cursor.execute(QUERY)
+    mysqlnoproc_client.commit()
+    cursor.close()
+    mysqlnoproc_client.close()


### PR DESCRIPTION
Fixes #340 .

Changes proposed:
 - Add Try/Except in mysql_conn.store_result() fixture block (only if mysql_conn is still open)
 - Add try/except block in dropping database
 - If connection is closed, try to reconnect again and drop test database