### PR TITLE
abort with a helpful message if we won't be able to start a server

### DIFF
--- a/newsfragments/345.bugfix.rst
+++ b/newsfragments/345.bugfix.rst
@@ -1,0 +1,6 @@
+Raise exception with helpful message if unixsocket is too long on FreeBSD or MacOS system
+
+OSX gives out super long temp directories.  This isn't a problem until
+we run into an odd 103-character limit on the names of unix sockets
+`see this stackoverflow thread <https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars/367012#367012>`_.
+Here we warn and give the user a way out of it.

--- a/pytest_mysql/exceptions.py
+++ b/pytest_mysql/exceptions.py
@@ -17,5 +17,9 @@ class VersionNotDetected(PytestMySQLException):
         super().__init__("Could not detect version in {}".format(output))
 
 
+class SocketPathTooLong(PytestMySQLException):
+    """Exception raised the socket path is over 103 chars (mysql will fail to start)."""
+
+
 class DatabaseExists(PytestMySQLException):
     """Raise this exception, when the database already exists."""

--- a/pytest_mysql/exceptions.py
+++ b/pytest_mysql/exceptions.py
@@ -18,7 +18,11 @@ class VersionNotDetected(PytestMySQLException):
 
 
 class SocketPathTooLong(PytestMySQLException):
-    """Exception raised the socket path is over 103 chars (mysql will fail to start)."""
+    """
+    Exception raised the socket path is over 103 chars.
+
+    Raised on BSD/MacOS as Mysql will fail to start.
+    """
 
 
 class DatabaseExists(PytestMySQLException):

--- a/pytest_mysql/executor.py
+++ b/pytest_mysql/executor.py
@@ -182,7 +182,11 @@ class MySQLExecutor(TCPExecutor):
         return super().stop(*args, **kwargs)
 
     def _check_socket_path(self) -> None:
-        if platform.system() in ["Darwin", "FreeBSD]"] and len(self.unixsocket) > 103:
+        if (
+            platform.system() in ["Darwin", "FreeBSD]"]
+            and len(self.unixsocket) > 103
+        ):
             raise SocketPathTooLong(
-                f"Socket path '{self.unixsocket}' is too long, please pass --basetemp=/tmp/pytest_mysql to pytest"
+                f"Socket path '{self.unixsocket}' is too long, "
+                f"please pass ie. `--basetemp=/tmp/pytest_mysql` to pytest"
             )


### PR DESCRIPTION
OSX gives out super long temp directories.  This isn't a problem until
we run into an odd 103-character limit on the names of unix sockets
(really?  really.).  Here we warn and give the user a way out of it.

I could also see just manually overriding the given base dir, but...
that's not my call to make.

Fixes #245 
