### PR TITLE
Make README agree with code: pytest.ini dbname

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ You can pick which you prefer, but remember that these settings are handled in t
    * - Test database name
      - dbname
      - --mysql-dbname
-     - mysqldbname
+     - mysql_dbname
      - -
      - test
    * - Starting parameters


### PR DESCRIPTION
If you attempt to specify a database name via `pytest.ini` as noted in the README, it fails.

See src/pytest_mysql/plugin.py line 67 for the underlying code.

Fixes buggy documentation.