### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/tests-mariadb.yml
+++ b/.github/workflows/tests-mariadb.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", pypy-3.8]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", pypy-3.8]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", pypy-3.8]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", pypy-3.8]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing


### PR DESCRIPTION
Fixes # n/a

Changes proposed: Run tests against Python 3.11 and add trove classifier