### PR TITLE
Fix license configuration in pyptoject.toml

### DIFF
--- a/newsfragments/426.bugfix.rst
+++ b/newsfragments/426.bugfix.rst
@@ -1,0 +1,1 @@
+Fix license configuration in pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.4.1"
 description = "MySQL process and client fixtures for pytest"
 readme = "README.rst"
 keywords = ["tests", "pytest", "fixture", "mysql"]
-license = {file = "LICENSE"}
+license = {file = "COPYING.lesser"}
 authors = [
     {name = "Grzegorz Śliwiński", email = "fizyk+pypi@fizyk.dev"}
 ]


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.