### PR TITLE
allow for flexible fixture scope

### DIFF
--- a/pytest_mysql/factories/client.py
+++ b/pytest_mysql/factories/client.py
@@ -35,6 +35,7 @@ def mysql(
     dbname: Optional[str] = None,
     charset: str = "utf8",
     collation: str = "utf8_general_ci",
+    scope="function",
 ) -> Callable[[FixtureRequest], Any]:
     """
     Client fixture factory for MySQL server.
@@ -77,7 +78,7 @@ def mysql(
             raise
         return mysql_conn
 
-    @pytest.fixture
+    @pytest.fixture(scope=scope)
     def mysql_fixture(
         request: FixtureRequest,
     ) -> Generator[MySQLdb.Connection, None, None]:


### PR DESCRIPTION
I have no idea if there's a different way to accomplish getting this fixture in a different scope; I'm working on some speed improvements that will allow me to re-use the schema but just call `TRUNCATE TABLE` at the end of each test run.  If that method works maybe it could be an alternate fixture here? IDK just spitballing LMK what you think

