### PR TITLE
Add missing user param

### DIFF
--- a/newsfragments/474.feature.rst
+++ b/newsfragments/474.feature.rst
@@ -1,0 +1,1 @@
+Add missing user param

--- a/pytest_mysql/executor.py
+++ b/pytest_mysql/executor.py
@@ -69,6 +69,7 @@ class MySQLExecutor(TCPExecutor):
             f"--datadir={self.datadir} "
             f"--pid-file={self.pidfile} "
             f"--port={port} "
+            f"--user={self.user} "
             f"--socket={self.unixsocket} "
             f"--log-error={self.logfile_path} "
             f"--tmpdir={self.base_directory} "


### PR DESCRIPTION
This adds the `user` parameter to the MySQL executor.

The issue is that the standard `python:3.10` docker container runs everything as root. While it's not advised to actually run Mariadb/MySQL as root for production, when running a large integration test that requires a MySQL database, inside a ConcourseCI job that runs the container as root, this fixture was failing with a permission denied error when attempting to run the mariadbd daemon, since the `mariadb-install-db` safe command was adding the the `--user` flag, so you'd have a DB installation that was properly getting created as `root` but then the mariadb user was getting started with a non root user.

`
mariadb-install-db --user=root --datadir=/private/tmp/pytest/pytest-mysql-mysql_my_proc0/mysqldata_22955 --tmpdir=/private/tmp/pytest/pytest-mysql-mysql_my_proc0
`

`
E           mirakuru.exceptions.ProcessExitedWithError: The process invoked by the <pytest_mysql.executor.MySQLExecutor: "mariadbd-safe --datadir=/tmp/pytest/pytest-mysql-mysql_my_proc0/mysqldata_3306 --pid-file=/tmp/pytest/pytest-mysql-mysql_my_proc0/mysql-server.3306.pid --port=3306 --socket=/tmp/pytest/pytest-mysql-mysql_my_proc0/mysql.3306.sock --log-error=/tmp/pytest/pytest-mysql-mysql_my_proc0/mysql-server.3306.log --tmpdir=/tmp/pytest/pytest-mysql-mysql_my_proc0 --skip-syslog --skip-grant-table" 0x4006d98280> executor has exited with a non-zero code: 1.
`

Work was _attempted_ to try and move it off root, but the problem is that when using `outputs` in a ConcourseCI job, the directory that gets created in order to move artifacts between tasks in a pipeline is owned by `root` with `700` permissions, and even trying to bake `sudo` into the container in order to try and `sudo cp` the artifacts out wasn't working due to an issue with the container filesystem being mounted without suid which causes the `sudo: effective uid is not 0` error that happens when trying to use sudo in containers.

So really, it was just easier to run the mariadb as root, rather than try and fight my container & CICD infrastructure 