### PR TITLE
add option to truncate tables but not drop DB at end of test run

### DIFF
--- a/pytest_mysql/config.py
+++ b/pytest_mysql/config.py
@@ -19,6 +19,7 @@ class MySQLConfigType(TypedDict):
     params: str
     logsdir: str
     install_db: str
+    preserve_schema: bool
 
 
 def get_config(request: FixtureRequest) -> MySQLConfigType:
@@ -40,5 +41,6 @@ def get_config(request: FixtureRequest) -> MySQLConfigType:
         "params": get_conf_option("params"),
         "logsdir": get_conf_option("logsdir"),
         "install_db": get_conf_option("install_db"),
+        "preserve_schema": get_conf_option("preserve_schema"),
     }
     return config

--- a/pytest_mysql/executor.py
+++ b/pytest_mysql/executor.py
@@ -34,6 +34,7 @@ class MySQLExecutor(TCPExecutor):
         port: int,
         timeout: int = 60,
         install_db: Optional[str] = None,
+        preserve_schema: bool = False,
     ) -> None:
         """Specialised Executor to run and manage MySQL server process.
 

--- a/pytest_mysql/plugin.py
+++ b/pytest_mysql/plugin.py
@@ -33,6 +33,7 @@ _help_user = "MySQL username"
 _help_passwd = "MySQL password"
 _help_dbname = "Test database name"
 _help_params = "Starting parameters for the MySQL"
+_help_preserve_schema = "TRUNCATE but do not the database after tests"
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -47,6 +48,12 @@ def pytest_addoption(parser: Parser) -> None:
         name="mysql_install_db",
         help=_help_install_db,
         default="mysql_install_db",
+    )
+
+    parser.addini(
+        name="mysql_preserve_schema",
+        help=_help_preserve_schema,
+        default=False,
     )
 
     parser.addini(name="mysql_host", help=_help_host, default="localhost")
@@ -100,6 +107,13 @@ def pytest_addoption(parser: Parser) -> None:
         metavar="path",
         dest="mysql_install_db",
         help=_help_install_db,
+    )
+
+    parser.addoption(
+        "--mysql-preserve-schema",
+        action="store",
+        dest="mysql_preserve_schema",
+        help=_help_preserve_schema,
     )
 
     parser.addoption(


### PR DESCRIPTION
fully dropping the database and re-creating it was consuming nearly 50% of the runtime of my test suite.  This methodology saves just a ton of time.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.