### PR TITLE
Fix mysqlclient installation in CI on macosx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,7 @@ jobs:
       with:
         mariadb-version: "11.1"
     - name: Install pkg-config
-      run: brew install pkg-config
+      run: brew install pkg-config openssl
     - name: Check MySQL Version
       run: mysqld --version
     - name: Run test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
-      PKG_CONFIG_PATH: /usr/local/opt/mysql@8.0/lib/pkgconfig
+      PKG_CONFIG_PATH: /opt/homebrew/opt/mysql@8.0/lib/pkgconfig
     steps:
     - uses: actions/checkout@v4
     - uses: ankane/setup-mysql@v1
@@ -116,7 +116,7 @@ jobs:
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
-      PKG_CONFIG_PATH: /usr/local/opt/mariadb@10.10/lib/pkgconfig
+      PKG_CONFIG_PATH: /opt/homebrew/opt/mariadb@11.1/lib/pkgconfig
     steps:
     - uses: actions/checkout@v4
     - uses: ankane/setup-mariadb@v1

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 pytest = "==7.4.3"
 port-for = "==0.7.2"
 mirakuru = "==2.5.2"
-mysqlclient = "==2.2.1"
+mysqlclient = "==2.2.4"
 packaging = "==23.2"
 
 [dev-packages]

--- a/newsfragments/520.misc.rst
+++ b/newsfragments/520.misc.rst
@@ -1,0 +1,1 @@
+Fix installation of mysqlclient on macosx for mariadb


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.