### PR TITLE
Update mariadb in tests from 11.1 to 11.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,17 +61,11 @@ jobs:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
 
-  tests-mariadb-linux-11_1:
+  tests-mariadb-linux-11:
     needs: [ tests-mysql-linux ]
     uses: ./.github/workflows/tests-mariadb-linux.yml
     with:
-      mariadb: 11.1
-
-  tests-mariadb-linux-11:
-    needs: [ tests-mariadb-linux-11_1 ]
-    uses: ./.github/workflows/tests-mariadb-linux.yml
-    with:
-      mariadb: "11.0"
+      mariadb: "11.4"
       python-versions: '["3.10", "3.11", "3.12"]'
 
   tests-mariadb-linux-10_11:
@@ -108,7 +102,7 @@ jobs:
 
   tests-mariadb-macosx:
     runs-on: macos-latest
-    needs: [tests-mysql-macosx, tests-mariadb-linux-11_1]
+    needs: [tests-mysql-macosx, tests-mariadb-linux-11]
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +115,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ankane/setup-mariadb@v1
       with:
-        mariadb-version: "11.1"
+        mariadb-version: "11.4"
     - name: Install pkg-config
       run: brew install pkg-config
     - name: Check MySQL Version

--- a/newsfragments/550.misc.rst
+++ b/newsfragments/550.misc.rst
@@ -1,0 +1,1 @@
+Update MariaDB from 11.1 to 11.4 in tests.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.