### PR TITLE
Fixed last piece of macosx environment setup after moving to pymysql

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,6 @@ jobs:
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
-      PKG_CONFIG_PATH: /usr/local/opt/mysql@8.0/lib/pkgconfig
     steps:
     - uses: actions/checkout@v4
     - uses: ankane/setup-mysql@v1
@@ -110,14 +109,11 @@ jobs:
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
-      PKG_CONFIG_PATH: /usr/local/opt/mariadb@10.10/lib/pkgconfig
     steps:
     - uses: actions/checkout@v4
     - uses: ankane/setup-mariadb@v1
       with:
         mariadb-version: "11.4"
-    - name: Install pkg-config
-      run: brew install pkg-config
     - name: Check MySQL Version
       run: mysqld --version
     - name: Run test

--- a/newsfragments/+174e1930.misc.rst
+++ b/newsfragments/+174e1930.misc.rst
@@ -1,0 +1,1 @@
+Fixed last piece of macosx environment setup after moving to pymysql


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.