### PR TITLE
Declare support for Python 3.13, drop support for Python 3.8

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: tbump --dry-run --only-patch $(pipenv run tbump current-version)"-x"
   towncrier:
     runs-on: ubuntu-latest
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: fizyk/actions-reuse/.github/actions/pipenv@v2.4.8
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           command: towncrier check --compare-with origin/main
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.8]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
@@ -66,14 +66,14 @@ jobs:
     uses: ./.github/workflows/tests-mariadb-linux.yml
     with:
       mariadb: "11.4"
-      python-versions: '["3.10", "3.11", "3.12"]'
+      python-versions: '["3.11", "3.12", "3.13"]'
 
   tests-mariadb-linux-10_11:
     needs: [ tests-mariadb-linux-11 ]
     uses: ./.github/workflows/tests-mariadb-linux.yml
     with:
       mariadb: 10.11
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
 
   tests-mysql-macosx:
     runs-on: macos-latest
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     env:
       OS: macos-latest
       PYTHON: ${{ matrix.python-version }}

--- a/newsfragments/+22232b9a.feature.rst
+++ b/newsfragments/+22232b9a.feature.rst
@@ -1,0 +1,1 @@
+Declare support for Python 3.13

--- a/newsfragments/+85a38e4a.break.rst
+++ b/newsfragments/+85a38e4a.break.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
@@ -34,7 +34,7 @@ dependencies = [
     "pymysql",
     "packaging >= 23"
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 "Source" = "https://github.com/ClearcodeHQ/pytest-mysql"
@@ -64,7 +64,7 @@ mysql_dbname = "pytestmysql"
 
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py39']
 include = '.*\.pyi?$'
 
 [tool.ruff]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -126,7 +126,8 @@ def test_exception_raised(verstr: bytes, tmp_path_factory: TempPathFactory) -> N
         port=8838,
     )
 
-    with patch("subprocess.check_output", lambda *args, **kwargs: verstr), pytest.raises(
-        MySQLUnsupported
+    with (
+        patch("subprocess.check_output", lambda *args, **kwargs: verstr),
+        pytest.raises(MySQLUnsupported),
     ):
         executor.start()


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.