### PR TITLE
Drop PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.rst
+++ b/.github/PULL_REQUEST_TEMPLATE.rst
@@ -1,5 +1,0 @@
-Chore that needs to be done:
-
-* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`
-
-Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.

--- a/newsfragments/+7c846d23.misc.rst
+++ b/newsfragments/+7c846d23.misc.rst
@@ -1,0 +1,1 @@
+Drop PR template, as the only check point there is already checked by coderabbit.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the pull request template by removing redundant manual checklist requirements. Automated verification tooling now manages tasks previously requiring manual intervention, simplifying the contribution process for developers and reducing operational friction whilst maintaining comprehensive quality assurance standards throughout the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->